### PR TITLE
Fix "Downloads" typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or
 
 SVG URL : `https://vsmarketplacebadge.apphb.com/installs-short/{publisher_name}.{extension_name}.svg`
 
-# Dowloads Badge
+# Downloads Badge
 *The total number of installs, including updates.*
 ![](image/cssho.vscode-svgviewer_dowloads.png)
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ SVG URL : `https://vsmarketplacebadge.apphb.com/installs-short/{publisher_name}.
 
 # Downloads Badge
 *The total number of installs, including updates.*
-![](image/cssho.vscode-svgviewer_dowloads.png)
+![](image/cssho.vscode-svgviewer_downloads.png)
 
-SVG URL : `https://vsmarketplacebadge.apphb.com/dowloads/{publisher_name}.{extension_name}.svg`
+SVG URL : `https://vsmarketplacebadge.apphb.com/downloads/{publisher_name}.{extension_name}.svg`
 
 or
 
-SVG URL : `https://vsmarketplacebadge.apphb.com/dowloads-short/{publisher_name}.{extension_name}.svg`
+SVG URL : `https://vsmarketplacebadge.apphb.com/downloads-short/{publisher_name}.{extension_name}.svg`
 
 # Rating Badge
 ![](image/ms-vscode_csharp.png)


### PR DESCRIPTION
Just noticed this when looking through the GitHub repo. Thanks for creating this, and keep up the great work!